### PR TITLE
feat: Add MacondoTech.EnterpriseBus.Common.AWS project

### DIFF
--- a/src/CTM.EnterpriseBus.sln
+++ b/src/CTM.EnterpriseBus.sln
@@ -28,6 +28,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MacondoTech.EnterpriseBus.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MacondoTech.EventSubscriber.Unity.Webjob", "Samples\MacondoTech.EventSubscriber.Unity.Webjob\MacondoTech.EventSubscriber.Unity.Webjob.csproj", "{8A409B71-860D-4964-AFB3-A17CC0794846}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MacondoTech.EnterpriseBus.Common.AWS", "MacondoTech.EnterpriseBus.Common.AWS\MacondoTech.EnterpriseBus.Common.AWS.csproj", "{1BFA8125-0EDE-41E4-B356-9F6130D57B59}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MacondoTech.EnterpriseBus.Common.AWS.UnitTests", "MacondoTech.EnterpriseBus.Common.AWS.UnitTests\MacondoTech.EnterpriseBus.Common.AWS.UnitTests.csproj", "{7810252C-90FE-40B6-861E-66DCEE7BF2ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -170,6 +174,30 @@ Global
 		{8A409B71-860D-4964-AFB3-A17CC0794846}.Release|x64.Build.0 = Release|Any CPU
 		{8A409B71-860D-4964-AFB3-A17CC0794846}.Release|x86.ActiveCfg = Release|Any CPU
 		{8A409B71-860D-4964-AFB3-A17CC0794846}.Release|x86.Build.0 = Release|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Debug|x64.Build.0 = Debug|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Debug|x86.Build.0 = Debug|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Release|x64.ActiveCfg = Release|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Release|x64.Build.0 = Release|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Release|x86.ActiveCfg = Release|Any CPU
+		{1BFA8125-0EDE-41E4-B356-9F6130D57B59}.Release|x86.Build.0 = Release|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Release|x64.Build.0 = Release|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{7810252C-90FE-40B6-861E-66DCEE7BF2ED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MacondoTech.EnterpriseBus.Common.AWS.UnitTests/AWSEnterpriseBusServiceTests.cs
+++ b/src/MacondoTech.EnterpriseBus.Common.AWS.UnitTests/AWSEnterpriseBusServiceTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MacondoTech.EnterpriseBus.Common.AWS.Configuration;
+using MacondoTech.EnterpriseBus.Common.AWS.Services;
+using MacondoTech.EnterpriseBus.Conventions;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace MacondoTech.EnterpriseBus.Common.AWS.UnitTests
+{
+    public class AWSEnterpriseBusServiceTests
+    {
+        private readonly Mock<IBusControl> _mockBusControl;
+        private readonly Mock<AWSBusConfiguration> _mockBusConfiguration;
+        private readonly Mock<AWSSettings> _mockAwsSettings;
+        private readonly Mock<ILogger<AWSEnterpriseBusService>> _mockLogger;
+        private readonly Mock<TopologyMap> _mockTopologyMap;
+
+        public AWSEnterpriseBusServiceTests()
+        {
+            _mockBusControl = new Mock<IBusControl>();
+            _mockAwsSettings = new Mock<AWSSettings>();
+            _mockTopologyMap = new Mock<TopologyMap>();
+            _mockBusConfiguration = new Mock<AWSBusConfiguration>(null, _mockAwsSettings.Object); // Pass null for resolver, use mocked AWSSettings
+            _mockBusConfiguration.Setup(c => c.TopologyMap).Returns(_mockTopologyMap.Object);
+            _mockBusConfiguration.Setup(c => c.AWSSettings).Returns(_mockAwsSettings.Object);
+            _mockLogger = new Mock<ILogger<AWSEnterpriseBusService>>();
+
+            // Default setup for valid AWS settings
+            _mockAwsSettings.Setup(s => s.IsValid()).Returns(true);
+            _mockAwsSettings.Setup(s => s.Region).Returns("us-east-1");
+            _mockAwsSettings.Setup(s => s.AccessKey).Returns("testAccessKey");
+            _mockAwsSettings.Setup(s => s.SecretKey).Returns("testSecretKey");
+        }
+
+        private AWSEnterpriseBusService CreateService()
+        {
+            return new AWSEnterpriseBusService(
+                _mockBusControl.Object,
+                _mockBusConfiguration.Object,
+                _mockLogger.Object);
+        }
+
+        [Fact]
+        public void Constructor_ThrowsArgumentNullException_WhenBusControlIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AWSEnterpriseBusService(null!, _mockBusConfiguration.Object, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_ThrowsArgumentNullException_WhenConfigurationIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AWSEnterpriseBusService(_mockBusControl.Object, null!, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_ThrowsArgumentNullException_WhenLoggerIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AWSEnterpriseBusService(_mockBusControl.Object, _mockBusConfiguration.Object, null!));
+        }
+
+        [Fact]
+        public void Constructor_ThrowsArgumentException_WhenAWSSettingsAreInvalid()
+        {
+            _mockAwsSettings.Setup(s => s.IsValid()).Returns(false);
+            Assert.Throws<ArgumentException>(() => CreateService());
+        }
+
+        [Fact]
+        public void Constructor_SetsNameProperty_FromTopologyMap()
+        {
+            _mockTopologyMap.Setup(t => t.DefaultEndPoint).Returns("TestEndpoint");
+            var service = CreateService();
+            Assert.Equal("TestEndpoint", service.Name);
+        }
+
+        [Fact]
+        public async Task Send_Generic_CallsBusControlGetSendEndpointAndSendsMessage()
+        {
+            // Arrange
+            var message = new TestMessage { Content = "Hello" };
+            var queueName = "test-queue";
+            var expectedUri = new Uri($"queue:{queueName}");
+            _mockTopologyMap.Setup(t => t.SendEndpoints).Returns(new Dictionary<Type, string> { { typeof(TestMessage), queueName } });
+            var mockSendEndpoint = new Mock<ISendEndpoint>();
+            _mockBusControl.Setup(b => b.GetSendEndpoint(expectedUri)).ReturnsAsync(mockSendEndpoint.Object);
+
+            var service = CreateService();
+
+            // Act
+            await service.Send(message);
+
+            // Assert
+            _mockBusControl.Verify(b => b.GetSendEndpoint(expectedUri), Times.Once);
+            mockSendEndpoint.Verify(s => s.Send(message, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Send_Object_CallsBusControlGetSendEndpointAndSendsMessage()
+        {
+            // Arrange
+            var message = new TestMessage { Content = "Hello Object" };
+            var queueName = "test-object-queue";
+            var expectedUri = new Uri($"queue:{queueName}");
+            _mockTopologyMap.Setup(t => t.SendEndpoints).Returns(new Dictionary<Type, string> { { typeof(TestMessage), queueName } });
+            var mockSendEndpoint = new Mock<ISendEndpoint>();
+            _mockBusControl.Setup(b => b.GetSendEndpoint(expectedUri)).ReturnsAsync(mockSendEndpoint.Object);
+
+            var service = CreateService();
+
+            // Act
+            await service.Send<TestMessage>(message);
+
+            // Assert
+            _mockBusControl.Verify(b => b.GetSendEndpoint(expectedUri), Times.Once);
+            mockSendEndpoint.Verify(s => s.Send<TestMessage>(message, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+
+        [Fact]
+        public async Task Send_Generic_ThrowsArgumentException_WhenMessageTypeNotMapped()
+        {
+            _mockTopologyMap.Setup(t => t.SendEndpoints).Returns(new Dictionary<Type, string>()); // Empty map
+            var service = CreateService();
+            var message = new UnmappedMessage();
+
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.Send(message));
+            Assert.Contains("Send endpoint not configured for message type", ex.Message);
+        }
+
+        [Fact]
+        public async Task Send_Generic_ThrowsArgumentNullException_WhenMessageIsNull()
+        {
+            var service = CreateService();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => service.Send<TestMessage>(null!));
+        }
+
+        [Fact]
+        public async Task Publish_Generic_CallsBusControlPublish()
+        {
+            // Arrange
+            var message = new TestEvent { EventData = "Boom!" };
+            var service = CreateService();
+
+            // Act
+            await service.Publish(message);
+
+            // Assert
+            _mockBusControl.Verify(b => b.Publish(message, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_Object_CallsBusControlPublish()
+        {
+            // Arrange
+            var message = new TestEvent { EventData = "Boom Object!" };
+            var service = CreateService();
+
+            // Act
+            await service.Publish<TestEvent>(message);
+
+            // Assert
+            _mockBusControl.Verify(b => b.Publish<TestEvent>(message, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Publish_Generic_ThrowsArgumentNullException_WhenMessageIsNull()
+        {
+            var service = CreateService();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => service.Publish<TestEvent>(null!));
+        }
+
+        [Fact]
+        public async Task StartAsync_CallsBusControlStartAsync()
+        {
+            var service = CreateService();
+            await service.StartAsync(CancellationToken.None);
+            _mockBusControl.Verify(b => b.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task StopAsync_CallsBusControlStopAsync()
+        {
+            var service = CreateService();
+            await service.StopAsync(CancellationToken.None);
+            _mockBusControl.Verify(b => b.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    // Helper classes for testing
+    public class TestMessage { public string? Content { get; set; } }
+    public class UnmappedMessage { public string? Data { get; set; } }
+    public class TestEvent { public string? EventData { get; set; } }
+}

--- a/src/MacondoTech.EnterpriseBus.Common.AWS.UnitTests/MacondoTech.EnterpriseBus.Common.AWS.UnitTests.csproj
+++ b/src/MacondoTech.EnterpriseBus.Common.AWS.UnitTests/MacondoTech.EnterpriseBus.Common.AWS.UnitTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="MassTransit.TestFramework" Version="8.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MacondoTech.EnterpriseBus.Common.AWS\MacondoTech.EnterpriseBus.Common.AWS.csproj" />
+    <ProjectReference Include="..\MacondoTech.EnterpriseBus.Conventions\MacondoTech.EnterpriseBus.Conventions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MacondoTech.EnterpriseBus.Common.AWS/Configuration/AWSBusConfiguration.cs
+++ b/src/MacondoTech.EnterpriseBus.Common.AWS/Configuration/AWSBusConfiguration.cs
@@ -1,0 +1,23 @@
+using MacondoTech.EnterpriseBus.Conventions;
+
+namespace MacondoTech.EnterpriseBus.Common.AWS.Configuration
+{
+    public class AWSBusConfiguration
+    {
+        /// <summary>
+        /// Gets the AWS settings.
+        /// </summary>
+        public AWSSettings AWSSettings { get; }
+
+        /// <summary>
+        /// Gets the message conventions (for messages, commands, and events).
+        /// </summary>
+        public TopologyMap TopologyMap { get; }
+
+        public AWSBusConfiguration(INamespaceResolver? resolver = null, AWSSettings? awsSettings = null)
+        {
+            AWSSettings = awsSettings ?? new AWSSettings();
+            TopologyMap = resolver != null ? resolver.BuildTopology() : new DefaultNamespaceResolver().BuildTopology();
+        }
+    }
+}

--- a/src/MacondoTech.EnterpriseBus.Common.AWS/Configuration/AWSSettings.cs
+++ b/src/MacondoTech.EnterpriseBus.Common.AWS/Configuration/AWSSettings.cs
@@ -1,0 +1,26 @@
+namespace MacondoTech.EnterpriseBus.Common.AWS.Configuration
+{
+    public class AWSSettings
+    {
+        public string Region { get; set; }
+        public string AccessKey { get; set; }
+        public string SecretKey { get; set; }
+        // Optional: SessionToken for temporary credentials
+        public string? SessionToken { get; set; }
+
+        public AWSSettings()
+        {
+            // Initialize with default values or leave empty for DI/configuration binding
+            Region = string.Empty;
+            AccessKey = string.Empty;
+            SecretKey = string.Empty;
+        }
+
+        public bool IsValid()
+        {
+            return !string.IsNullOrEmpty(Region) &&
+                   !string.IsNullOrEmpty(AccessKey) &&
+                   !string.IsNullOrEmpty(SecretKey);
+        }
+    }
+}

--- a/src/MacondoTech.EnterpriseBus.Common.AWS/MacondoTech.EnterpriseBus.Common.AWS.csproj
+++ b/src/MacondoTech.EnterpriseBus.Common.AWS/MacondoTech.EnterpriseBus.Common.AWS.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackageId>MacondoTech.EnterpriseBus.Common.AWS</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>miguel saldarriaga</Authors>
+    <Company>MacondoTech</Company>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MassTransit.AmazonSQS" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../MacondoTech.EnterpriseBus.Conventions/MacondoTech.EnterpriseBus.Conventions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MacondoTech.EnterpriseBus.Common.AWS/Services/AWSEnterpriseBusService.cs
+++ b/src/MacondoTech.EnterpriseBus.Common.AWS/Services/AWSEnterpriseBusService.cs
@@ -1,0 +1,154 @@
+using MacondoTech.EnterpriseBus.Common.AWS.Configuration;
+using MacondoTech.EnterpriseBus.Common.Services; // For ICTMEnterpriseBus, IPublishMessages, ISendMessages
+using MacondoTech.EnterpriseBus.Conventions; // For TopologyMap
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MacondoTech.EnterpriseBus.Common.AWS.Services
+{
+    public class AWSEnterpriseBusService : ICTMEnterpriseBus // Implements ISendMessages, IPublishMessages, IHostedService
+    {
+        private readonly IBusControl _busControl;
+        private readonly AWSBusConfiguration _configuration;
+        private readonly ILogger<AWSEnterpriseBusService> _logger;
+
+        public string Name => _configuration?.TopologyMap.DefaultEndPoint ?? "MacondoTech.AWS.DefaultEndpoint";
+
+        public AWSEnterpriseBusService(IBusControl busControl, AWSBusConfiguration configuration, ILogger<AWSEnterpriseBusService> logger)
+        {
+            _busControl = busControl ?? throw new ArgumentNullException(nameof(busControl));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            if (_configuration.AWSSettings == null || !_configuration.AWSSettings.IsValid())
+            {
+                _logger.LogError("AWS Settings are not properly configured.");
+                throw new ArgumentException("AWS Settings are not properly configured.", nameof(configuration.AWSSettings));
+            }
+        }
+
+        public async Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
+        {
+            try
+            {
+                if (message == null) throw new ArgumentNullException(nameof(message));
+
+                var destinationAddress = GetSendEndpointAddress<T>();
+                _logger.LogInformation("Getting send endpoint for {DestinationAddress}", destinationAddress);
+                ISendEndpoint sendEndpoint = await _busControl.GetSendEndpoint(destinationAddress);
+
+                _logger.LogInformation("Sending message: {MessageType} to {DestinationAddress}, {@Message}", typeof(T).FullName, destinationAddress, message);
+                await sendEndpoint.Send(message, cancellationToken);
+                _logger.LogInformation("Sent message: {MessageType} to {DestinationAddress}", typeof(T).FullName, destinationAddress);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send message: {MessageType}, {@Message}", typeof(T).FullName, message);
+                throw;
+            }
+        }
+
+        public async Task Send<T>(object message, CancellationToken cancellationToken = default) where T : class
+        {
+            try
+            {
+                if (message == null) throw new ArgumentNullException(nameof(message));
+
+                var destinationAddress = GetSendEndpointAddress<T>();
+                 _logger.LogInformation("Getting send endpoint for {DestinationAddress}", destinationAddress);
+                ISendEndpoint sendEndpoint = await _busControl.GetSendEndpoint(destinationAddress);
+
+                _logger.LogInformation("Sending message: {MessageType} to {DestinationAddress}, {@Message}", typeof(T).FullName, destinationAddress, message);
+                await sendEndpoint.Send<T>(message, cancellationToken);
+                _logger.LogInformation("Sent message: {MessageType} to {DestinationAddress}", typeof(T).FullName, destinationAddress);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send message: {MessageType}, {@Message}", typeof(T).FullName, message);
+                throw;
+            }
+        }
+
+        private Uri GetSendEndpointAddress<T>() where T : class
+        {
+            if (!_configuration.TopologyMap.SendEndpoints.TryGetValue(typeof(T), out var queueName))
+            {
+                _logger.LogError("Send endpoint not found for message type {MessageType}", typeof(T).FullName);
+                throw new ArgumentException($"Send endpoint not configured for message type {typeof(T).FullName}. Ensure it is registered in TopologyMap.SendEndpoints.");
+            }
+            // For SQS, the address is just the queue name. MassTransit handles the full ARN construction.
+            // However, MassTransit's GetSendEndpoint usually expects a full URI like 'queue:queueName' or 'topic:topicName'.
+            // Let's assume queueName from TopologyMap is just the queue name for now.
+            // We might need to adjust this based on how MassTransit SQS addressing works,
+            // potentially prepending "queue:" or "topic:" if needed, or relying on MassTransit's conventions.
+            // For SQS, it's typically just the queue name if the bus is configured with a base URI.
+            // If not, it might need 'amazonsqs://host/queueName'.
+            // Given MassTransit's IBusControl.GetSendEndpoint, a simple queue name might resolve if a convention is set up.
+            // Or, more robustly, "queue:{queueName}" or "topic:{topicName}"
+            return new Uri($"queue:{queueName}");
+        }
+
+        public async Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class
+        {
+            try
+            {
+                if (message == null) throw new ArgumentNullException(nameof(message));
+                _logger.LogInformation("Publishing event: {MessageType}, {@Message}", typeof(T).FullName, message);
+                await _busControl.Publish(message, cancellationToken);
+                _logger.LogInformation("Published event: {MessageType}", typeof(T).FullName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Publish event error: {MessageType}, {@Message}", typeof(T).FullName, message);
+                throw;
+            }
+        }
+
+        public async Task Publish<T>(object message, CancellationToken cancellationToken = default) where T : class
+        {
+            try
+            {
+                if (message == null) throw new ArgumentNullException(nameof(message));
+                _logger.LogInformation("Publishing event: {MessageType}, {@Message}", typeof(T).FullName, message);
+                await _busControl.Publish<T>(message, cancellationToken);
+                _logger.LogInformation("Published event: {MessageType}", typeof(T).FullName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Publish event error: {MessageType}, {@Message}", typeof(T).FullName, message);
+                throw;
+            }
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.LogInformation("AWSEnterpriseBusService starting...");
+                return _busControl.StartAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AWSEnterpriseBusService start error");
+                throw;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.LogInformation("AWSEnterpriseBusService stopping...");
+                return _busControl.StopAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AWSEnterpriseBusService stop error");
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new library project, `MacondoTech.EnterpriseBus.Common.AWS`, which provides functionality similar to `MacondoTech.EnterpriseBus.Common` but utilizes AWS SQS and SNS for messaging via MassTransit.

Key changes include:
- Creation of the `MacondoTech.EnterpriseBus.Common.AWS` project.
- Addition of `AWSSettings` and `AWSBusConfiguration` for AWS-specific configuration, while reusing `TopologyMap` from the Conventions project.
- Implementation of `AWSEnterpriseBusService` which implements `ICTMEnterpriseBus` (including `ISendMessages`, `IPublishMessages`, and `IHostedService`) using MassTransit for AWS.
- The new project is added to the main solution file.
- A new unit test project, `MacondoTech.EnterpriseBus.Common.AWS.UnitTests`, has been created with initial tests for `AWSEnterpriseBusService`, mocking dependencies using Moq and testing core send/publish logic.

This new project allows for integration with AWS messaging services, maintaining a consistent interface with the existing Azure-based common library.